### PR TITLE
build: modify workflows to use apt and ignore deb build result

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,5 +14,5 @@ jobs:
         uses: threeal/ros2-ci@v1.0.0
         with:
           ros2-distro: foxy
-          apt-packages: ros-foxy-gazebo-ros
-          external-repos: threeal/tosshin#v0.2.0 ichiro-its/keisan#v0.2.0
+          pre-install: sudo apt update && sudo apt install -y curl && curl -s http://repository.ichiro-its.org/debian/setup.bash | bash -s
+          apt-packages: ros-foxy-gazebo-ros ros-foxy-keisan ros-foxy-tosshin-cpp

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 build
 log
 install
+
+debian
+obj-x86_64-linux-gnu
+
+*.deb
+*.ddeb

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tosshin_gazebo_plugins</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Gazebo plugins implementation of Tosshin mobile robot navigation project</description>
   <maintainer email="alfi.maulana.f@gmail.com">Alfi Maulana</maintainer>
   <license>MIT License</license>


### PR DESCRIPTION
- Modify workflows to use packages from Apt.
- Ignore debian build result.
- Bump version to 0.3.0.